### PR TITLE
Set up game header area

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,5 +10,6 @@ export default {
     scene:[
         LoadingScene,
         GameScene
-    ]
+    ],
+    backgroundColor: '#faf8f0'
 }

--- a/src/scenes/gameScene.js
+++ b/src/scenes/gameScene.js
@@ -1,9 +1,15 @@
-
 import Phaser from "phaser";
+
+const GRID_SIZE = 4;
+const TILE_SIZE = 75;
+const GAP = 10;
 
 export default class GameScene extends Phaser.Scene {
     constructor() {
         super("GameScene");
+        this.board = [];
+        this.score = 0;
+        this.bestScore = 0;
     }
 
     preload() {
@@ -11,7 +17,48 @@ export default class GameScene extends Phaser.Scene {
     }
 
     create() {
+        // Add header text '2048'
+        const headerText = this.add.text(20, 50, '2048', {
+            font: 'bold 72px sans-serif',
+            fill: '#645f59'
+        });
+        headerText.setOrigin(0, 0.5);
 
+        // Create score area
+        const scoreContainer = this.add.container(255, 50);
+
+        const scoreBackground = this.add.rectangle(0, 0, 150, 75, 0xbaac9f);
+        const scoreHeading = this.add.text(0, -20, 'Score', {
+            font: 'bold 24px sans-serif',
+            fill: '#e8dacd'
+        });
+        scoreHeading.setOrigin(0.5);
+
+        this.scoreText = this.add.text(0, 10, this.score, {
+            font: 'bolder 32px sans-serif',
+            fill: '#ffffff'
+        });
+        this.scoreText.setOrigin(0.5);
+
+        scoreContainer.add([scoreBackground, scoreHeading, this.scoreText]);
+
+        // Create best score area
+        const bestScoreContainer = this.add.container(415, 50);
+
+        const bestScoreBackground = this.add.rectangle(0, 0, 150, 75, 0xbaac9f);
+        const bestScoreHeading = this.add.text(0, -20, 'Best Score', {
+            font: 'bold 24px sans-serif',
+            fill: '#e8dacd'
+        });
+        bestScoreHeading.setOrigin(0.5);
+
+        this.bestScoreText = this.add.text(0, 10, this.bestScore, {
+            font: 'bolder 32px sans-serif',
+            fill: '#ffffff'
+        });
+        this.bestScoreText.setOrigin(0.5);
+
+        bestScoreContainer.add([bestScoreBackground, bestScoreHeading, this.bestScoreText]);
     }
 
     update() {


### PR DESCRIPTION
Fixes #1

Add header text, game variables, and score areas to GameScene.

* Set the background color in `src/config.js` to match the one set for `#game` in `src/style.css`.
* Add header text '2048' to the `create` method in `src/scenes/gameScene.js` with font sans-serif 72px, bold, color #645f59, and origin (0, 0.5).
* Define game variables `board`, `score`, and `bestScore` in the constructor of `GameScene`.
* Create a score area in the `create` method of `GameScene`:
  * Add a container at (255, 50).
  * Add a score background that is a 150x75 rectangle with color 0xbaac9f.
  * Add a score heading that reads "Score" at 0, -20 with color #e8dacd, font bold 24px sans-serif, and origin set to the middle of the text.
  * Add score text to display the score variable at (0, 10) with color #ffffff, font bolder 32px sans-serif, and origin set to the middle of the text.
  * Add the background, heading, and text to the container.
* Create a best score area next to the score area in the `create` method of `GameScene`:
  * Add a container at (415, 50).
  * Add a best score background that is a 150x75 rectangle with color 0xbaac9f.
  * Add a best score heading that reads "Best Score" at 0, -20 with color #e8dacd, font bold 24px sans-serif, and origin set to the middle of the text.
  * Add best score text to display the bestScore variable at (0, 10) with color #ffffff, font bolder 32px sans-serif, and origin set to the middle of the text.
  * Add the background, heading, and text to the container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jacola/js2048/issues/1?shareId=15747faa-8eda-4e1e-b331-c3e901a70a9e).