### PR TITLE
Add animation when new tile is created

### DIFF
--- a/src/scenes/gameScene.js
+++ b/src/scenes/gameScene.js
@@ -186,6 +186,16 @@ export default class GameScene extends Phaser.Scene {
 
         tileContainer.add([tileBackground, tileText]);
         boardContainer.add(tileContainer);
+
+        tileContainer.setScale(0.5);
+        this.tweens.add({
+            targets: tileContainer,
+            scale: 1,
+            duration: 250,
+            ease: 'Cubic.easeOut'
+        });
+
+        return tileContainer;
     }
 
     getBackgroundColor(value) {


### PR DESCRIPTION
Related to #10

Add animation when a new tile is created.

* Modify the `createTile` function to return the `tileContainer`.
* Add a tween to the `tileContainer` in the `createTile` function.
* Set the scale of the `tileContainer` to 0.5 in the `createTile` function.
* Scale the `tileContainer` to 1.0 using `Cubic.easeOut` with a duration of 250ms in the `createTile` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jacola/js2048/issues/10?shareId=ccf4f294-c84e-45a8-9a5d-955031b28fb0).