### PR TITLE
Fix naming mistake

### DIFF
--- a/src/scenes/gameScene.js
+++ b/src/scenes/gameScene.js
@@ -157,10 +157,11 @@ export default class GameScene extends Phaser.Scene {
                 const value = this.board[row][col];
                 if (value !== 0) {
                     const tileName = `tile-${row}-${col}`;
-                    let tileText = boardContainer.getByName(tileName);
-                    if (!tileText) {
+                    let tileContainer = boardContainer.getByName(tileName);
+                    if (!tileContainer) {
                         this.createTile(boardContainer, row, col, value);
                     } else {
+                        let tileText = tileContainer.getAt(1);
                         tileText.setText(value);
                     }
                 }
@@ -182,7 +183,8 @@ export default class GameScene extends Phaser.Scene {
             fill: this.getTextColor(value)
         });
         tileText.setOrigin(0.5);
-        tileText.setName(`tile-${row}-${col}`);
+
+        tileContainer.setName(`tile-${row}-${col}`);
 
         tileContainer.add([tileBackground, tileText]);
         boardContainer.add(tileContainer);


### PR DESCRIPTION
Fixes #12

Fix the naming mistake by setting the name on the `tileContainer` instead of the `tileText`.

* Change line 185 to set the name on `tileContainer` instead of `tileText`.
* Update `updateBoard` method to get the `tileContainer` by name instead of `tileText`.
* Update `updateBoard` method to set the text on `tileText` inside the `tileContainer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jacola/js2048/issues/12?shareId=a4388f39-746e-4cee-9473-b0542547930f).